### PR TITLE
Fix instrumentation test package name

### DIFF
--- a/app/src/androidTest/java/com/firexrwtinc/mytime/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/firexrwtinc/mytime/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.firexrwtinc.myapplication", appContext.packageName)
+        assertEquals("com.firexrwtinc.mytime", appContext.packageName)
     }
 }


### PR DESCRIPTION
## Summary
- update ExampleInstrumentedTest package assertion

## Testing
- `./gradlew app:assembleDebugAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449c1ba33c832bbf58268833c4b7f8